### PR TITLE
Initial setup as minimum and dummy tags.json

### DIFF
--- a/app/controllers/smash_tags_controller.rb
+++ b/app/controllers/smash_tags_controller.rb
@@ -1,0 +1,33 @@
+class SmashTagsController < ApplicationController
+
+  before_action :find_project_by_project_id
+  before_action :authorize
+
+  accept_api_auth :index
+
+  def index
+    example = [{
+      sectionname: "[GTT] Task note",
+      sectiondescription: "GTT task with image",
+      sectionnicon: "image",
+      forms: [
+        {
+          formname: "Take a photo",
+          formitems: [
+            {
+              key: "title",
+              islabel: "true",
+              value: "",
+              icon: "infoCircle",
+              type: "string",
+              mandatory: "yes"
+            }
+          ]
+        }
+      ]
+    }]
+    respond_to do |format|
+      format.api { render json: example }
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,3 @@
+# English strings go here for Rails i18n
+en:
+  # my_label: "My label"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,6 @@
+# Plugin's routes
+# See: http://guides.rubyonrails.org/routing.html
+
+scope 'projects/:project_id' do
+  resources :smash_tags, only: %i(index), as: :project_smash_tags
+end

--- a/init.rb
+++ b/init.rb
@@ -1,0 +1,22 @@
+require 'redmine'
+
+Redmine::Plugin.register :redmine_gtt_smash do
+  name 'Redmine GTT SMASH Plugin'
+  author 'Georepublic'
+  description 'Adds SMASH integration capabilities for GTT projects'
+  version '0.0.1'
+  url 'https://github.com/gtt-project/redmine_gtt_smash'
+  author_url 'https://github.com/gtt-project'
+
+  requires_redmine :version_or_higher => '4.0.0'
+
+  # settings default: {
+  # }, partial: 'settings/gtt_smash_settings'
+
+  project_module :gtt_smash do
+    permission :view_gtt_smash, {
+      smash_tags: %i( index )
+    }, require: :member, read: true
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,2 @@
+# Load the Redmine helper
+require File.expand_path(File.dirname(__FILE__) + '/../../../test/test_helper')


### PR DESCRIPTION
Fixes # 1.

Changes proposed in this pull request:
- Just minimum setup.
- Enabling the followings is necessary:
   - Settings / API: http://localhost:3000/settings?tab=api
      - `Enable REST web service`: ON
   - Project settings: http://localhost:3000/projects/(project-identifier)/settings
      - `Modules` / `Gtt smash`: ON
   - Roles and permissions: http://localhost:3000/roles/(role-id)/edit
      - `Gtt smash` / `View gtt smash` 

Then, you can fetch tags.json from the following path:
- http://localhost:3000/projects/(project-identifier/smash_tags.json?key=(API-access-key)

Currently, the contents of response JSON is dummy, and it is specified at here:
- https://github.com/gtt-project/redmine_gtt_smash/blob/feature/create_basic/app/controllers/smash_tags_controller.rb#L9-L28

I will try to map Redmine object <=> SMASH object from the following Geopaparazzi spec, later:
- https://www.geopaparazzi.org/geopaparazzi/index.html#_using_form_based_notes

@gtt-project/maintainer
