### PR TITLE
Supporting dynamic tags.json output

### DIFF
--- a/app/controllers/smash_tags_controller.rb
+++ b/app/controllers/smash_tags_controller.rb
@@ -28,13 +28,13 @@ class SmashTagsController < ApplicationController
             # Default fields
             {
               key: "project_id",
-              value: @project.id,
+              value: @project.id.to_s,
               type: "hidden",
               mandatory: "yes"
             },
             {
               key: "tracker_id",
-              value: tracker.id,
+              value: tracker.id.to_s,
               type: "hidden",
               mandatory: "yes"
             },

--- a/app/controllers/smash_tags_controller.rb
+++ b/app/controllers/smash_tags_controller.rb
@@ -6,28 +6,77 @@ class SmashTagsController < ApplicationController
   accept_api_auth :index
 
   def index
-    example = [{
-      sectionname: "[GTT] Task note",
-      sectiondescription: "GTT task with image",
-      sectionnicon: "image",
-      forms: [
-        {
-          formname: "Take a photo",
+    smash_tags = []
+    priorities = []
+    default_priority = nil
+    IssuePriority.active.each do |priority|
+      priorities.append({
+        item: priority.name
+      })
+      if priority.is_default
+        default_priority = priority.name
+      end
+    end
+    @project.trackers.sort.each do |tracker|
+      section = {
+        sectionname: tracker.name,
+        sectiondescription: "",
+        sectionicon: "image",
+        forms: [{
+          formname: tracker.name,
           formitems: [
+            # Default fields
             {
-              key: "title",
-              islabel: "true",
+              key: "project_id",
+              value: @project.id,
+              type: "hidden",
+              mandatory: "yes"
+            },
+            {
+              key: "tracker_id",
+              value: tracker.id,
+              type: "hidden",
+              mandatory: "yes"
+            },
+            {
+              key: "subject",
+              label: l(:field_subject),
               value: "",
-              icon: "infoCircle",
               type: "string",
               mandatory: "yes"
+            },
+            {
+              key: "priority_id",
+              label: l(:field_priority),
+              values: {
+                items: priorities
+              },
+              value: default_priority,
+              type: "stringcombo",
+              mandatory: "yes"
+            },
+            {
+              key: "is_private",
+              label: l(:field_is_private),
+              type: "boolean",
+              mandatory: "yes"
+            },
+            # TODO: Need to check 
+            # assigned_to_id, category_id, fixed_version_id, parent_issue_id,
+            # start_date, due_date, estimated_hours, done_ratio
+            {
+              key: "description",
+              label: l(:field_description),
+              value: "",
+              type: "string"
             }
           ]
-        }
-      ]
-    }]
+        }]
+      }
+      smash_tags.append(section)
+    end
     respond_to do |format|
-      format.api { render json: example }
+      format.api { render json: smash_tags }
     end
   end
 end

--- a/app/controllers/smash_tags_controller.rb
+++ b/app/controllers/smash_tags_controller.rb
@@ -9,6 +9,7 @@ class SmashTagsController < ApplicationController
     smash_tags = []
     priorities = []
     default_priority = nil
+    # SMASH (Geopaparazzi) form spec: https://www.geopaparazzi.org/geopaparazzi/index.html#_using_form_based_notes
     IssuePriority.active.each do |priority|
       priorities.append({
         item: priority.name
@@ -73,6 +74,68 @@ class SmashTagsController < ApplicationController
           ]
         }]
       }
+      # Attachments
+      section[:forms][0][:formitems].append({
+        key: "attachments",
+        value: "",
+        type: "pictures"
+      })
+      # IssueCustomField mapping
+      # Redmine: https://github.com/redmine/redmine/blob/master/lib/redmine/field_format.rb
+      IssueCustomField.where(is_for_all: true).sort.each do |icf|
+        type = "string"
+        values = []
+        case icf.field_format
+        when "string", "text", "link"
+          type = "string"
+        when "int"
+          type = "integer"
+        when "float"
+          type = "double"
+        when "date"
+          type = "date"
+        when "bool"
+          type = "boolean"
+        when "list"
+          type = (icf.multiple ? "multistringcombo" : "stringcombo")
+          icf.possible_values.each do |v|
+            values.append({
+              item: v
+            })
+          end
+        when "enumeration"
+          type = (icf.multiple ? "multistringcombo" : "stringcombo")
+          icf.enumerations.where(active: true).sort.each do |e|
+            values.append({
+              item: e.name
+            })
+          end
+        when "user", "version", "attachment"
+          # Can't map SMASH object
+          type = "hidden"
+        end
+        if !icf.visible
+          type = "hidden"
+        end
+        value = (icf.default_value ? icf.default_value : "")
+        mandatory = (icf.is_required ? "true" : "false")
+
+        formitem = {
+          key: "cf_#{icf.id}",
+          label: icf.name,
+          value: value,
+          type: type,
+          mandatory: mandatory
+        }
+
+        if type.end_with?("stringcombo")
+          formitem[:values] = {
+            items: values
+          }
+        end
+
+        section[:forms][0][:formitems].append(formitem)
+      end
       smash_tags.append(section)
     end
     respond_to do |format|


### PR DESCRIPTION
Signed-off-by: Ko Nagase <nagase@georepublic.co.jp>

Supports #8.

Changes proposed in this pull request:
- [x] Tracker <=> Section mapping
- [x] Basic fields
- [x] IssuePriority
- [x] CustomFields
- [x] Attachments
- [ ] Roles and Permissions check
- [ ] Workflow level field control (`Read-only`/`Required`)

Links:
- https://www.geopaparazzi.org/geopaparazzi/index.html#_using_form_based_notes

@gtt-project/maintainer
