### PR TITLE
Use 'GTT' as sectiondescription

### DIFF
--- a/app/controllers/smash_tags_controller.rb
+++ b/app/controllers/smash_tags_controller.rb
@@ -121,7 +121,7 @@ class SmashTagsController < ApplicationController
       end
       section = {
         sectionname: tracker.name,
-        sectiondescription: tracker.description,
+        sectiondescription: "GTT",
         sectionicon: "image",
         forms: [{
           formname: tracker.name,


### PR DESCRIPTION
Supports #22.

Changes proposed in this pull request:
- Use fixed `GTT` value as `sectiondescription` value.

@gtt-project/maintainer
