### PR TITLE
Set is_private default value false

### DIFF
--- a/app/controllers/smash_tags_controller.rb
+++ b/app/controllers/smash_tags_controller.rb
@@ -173,6 +173,7 @@ class SmashTagsController < ApplicationController
             {
               key: "is_private",
               label: l(:field_is_private),
+              value: "false",
               type: "boolean",
               mandatory: "yes"
             }


### PR DESCRIPTION
Signed-off-by: Ko Nagase <nagase@georepublic.co.jp>

Fixes #26.

Changes proposed in this pull request:
- Set `is_private` default value `false`.

@gtt-project/maintainer
